### PR TITLE
Avoid plain printk()

### DIFF
--- a/src/cdadrv.c
+++ b/src/cdadrv.c
@@ -159,7 +159,7 @@ static int cda_pci_init(struct pci_dev *pcidev)
 	int ret;
 	ret = pci_enable_device_mem(pcidev);
 	if( ret ) {
-        printk("Cannot enable PCI device mem\n");
+		dev_err(&pcidev->dev, "Cannot enable PCI device mem\n");
 		goto err_en_devmem;
 	}
 

--- a/src/cdamem.c
+++ b/src/cdamem.c
@@ -743,7 +743,7 @@ int cda_map_mem(struct cda_dev *dev, void *owner, void __user *ureq)
 	list_add(&memmap->list, &dev->mem_maps);
 	spin_unlock(&dev->mblk_sl);
 
-	//printk("map vaddr %p, pages %d\n", memmap->vaddr, npages);
+	dev_dbg(&dev->dev, "map vaddr %p, pages %d\n", memmap->vaddr, npages);
 	return 0;
 
 err_copy_to_user:
@@ -770,7 +770,7 @@ out:
 
 static void cda_free_map(struct cda_mmap *memmap)
 {
-	//printk("unmap vaddr %p, pages %d\n", memmap->vaddr, memmap->blk_cnt);
+	dev_dbg(&memmap->dev->dev, "unmap vaddr %p, pages %d\n", memmap->vaddr, memmap->blk_cnt);
 	cda_hide_memmap(memmap);
 	cda_release_map(memmap);
 	kobject_put(&memmap->kobj);

--- a/src/cdares.c
+++ b/src/cdares.c
@@ -96,7 +96,7 @@ int cda_init_interrupts(struct cda_dev *cdadev, void *owner, void __user *ureq)
 	struct cda_interrupts *ints;
 
 	if( cdadev->ints ) {
-		//printk("Interrupts are already attached");
+		dev_dbg(&cdadev->pcidev->dev, "Interrupts are already attached");
 		return -EINVAL; // Already attached
 	}
 	if( copy_from_user(&req, (void __user *)ureq, sizeof(req)) )
@@ -195,7 +195,7 @@ int cda_free_irqs(struct cda_dev *cdadev, void *owner)
 	if( cdadev->ints == NULL )
 		return -EINVAL;
 	if( cdadev->ints->owner != owner ) {
-		//dev_err(&cdadev->pcidev->dev, "Interrupts are not owned by %p", owner);
+		dev_dbg(&cdadev->pcidev->dev, "Interrupts are not owned by %p", owner);
 		return -EINVAL;
 	}
 	mutex_lock(&cdadev->ilock);
@@ -262,7 +262,7 @@ int cda_req_int(struct cda_dev *cdadev, void *owner, void __user *ureq)
 		vec->busy = false;
 	}
 	mutex_unlock(&cdadev->ilock);
-	//printk("Interrupt vector %d timeout: %ld count %u reset %d\n", req.vector, timeout, count, req.reset);
+	dev_dbg(&cdadev->pcidev->dev, "Interrupt vector %d timeout: %ld count %u reset %d\n", req.vector, timeout, count, req.reset);
 	return timeout > 0 ? 0 : timeout == 0 ? -ETIME : timeout;
 }
 
@@ -274,7 +274,7 @@ int cda_cancel_req(struct cda_dev *cdadev, void *owner)
 		return -EINVAL;
 
 	if( cdadev->ints->owner != owner ) {
-		//dev_err(&cdadev->pcidev->dev, "Interrupts are not owned by %p", owner);
+		dev_dbg(&cdadev->pcidev->dev, "Interrupts are not owned by %p", owner);
 		return -EINVAL;
 	}
 
@@ -493,7 +493,7 @@ int cda_open_bars(struct cda_dev *cdadev)
 		//Drop busy bit
 		res_child = cdadev->pcidev->resource[i].child;
 
-		printk("Store resource %d flag: 0x%lx\n", i, res_child->flags);
+		dev_info(&cdadev->dev, "Store resource %d flag: 0x%lx\n", i, res_child->flags);
 		cdadev->stored_flags[i] = res_child->flags;
 		if (IORESOURCE_BUSY & res_child->flags) {
 			res_child->flags &= ~IORESOURCE_BUSY;
@@ -522,7 +522,7 @@ void cda_release_bars(struct cda_dev *cdadev)
 
 		if( bars & (1 << i) ) {
 			cdadev->pcidev->resource[i].child->flags = cdadev->stored_flags[i];
-			printk("Restore resource %d flag: %lx\n", i, cdadev->stored_flags[i]);
+			dev_info(&cdadev->dev, "Restore resource %d flag: %lx\n", i, cdadev->stored_flags[i]);
 		}
 	}
 
@@ -541,10 +541,10 @@ int cda_open_bars(struct cda_dev *cdadev)
 		if( bars & (1 << i) ) {
 			res_child = cdadev->pcidev->resource[i].child;
 			cdadev->stored_flags[i] = res_child->flags;
-			printk("Store resource %d flag: 0x%lx\n", i, res_child->flags);
+			dev_info(&cdadev->dev, "Store resource %d flag: 0x%lx\n", i, res_child->flags);
 			if( IORESOURCE_BUSY & res_child->flags ) {
 				res_child->flags &= ~IORESOURCE_BUSY;
-				//printk("Drop busy bit for resource %d", i);
+				dev_dbg(&cdadev->dev, "Drop busy bit for resource %d", i);
 			}
 		}
 	}
@@ -558,7 +558,7 @@ void cda_release_bars(struct cda_dev *cdadev)
 	for( i = 0; i < PCI_ROM_RESOURCE; i++ ) {
 		if( bars & (1 << i) ) {
 			cdadev->pcidev->resource[i].child->flags = cdadev->stored_flags[i];
-			printk("Restore resource %d flag: %lx\n", i, cdadev->stored_flags[i]);
+			dev_info(&cdadev->dev, "Restore resource %d flag: %lx\n", i, cdadev->stored_flags[i]);
 		}
 	}
 }


### PR DESCRIPTION
Replace `printk()` in device driver code with `dev_info()`.
This helps show which driver emits the messages about storing and restoring resources.

Also update commented-out `printk()` and `dev_err()` to `dev_dbg()`.
This gets them build-testing while still not printing by default.