### PR TITLE
Workflow update for v4 and ubuntu-20.04

### DIFF
--- a/.github/workflows/build-dsc.yml
+++ b/.github/workflows/build-dsc.yml
@@ -9,7 +9,7 @@ on:
         default: ""
 jobs:
   Build-DSC-Repo:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install prerequisites and set up git
         run: |
@@ -49,7 +49,7 @@ jobs:
         run: debuild -b
         working-directory: ${{ github.workspace }}/workspace
       - name: upload the debian pkg
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cdapci
           path: ${{ github.workspace }}/cdapci-dkms_${{ steps.version.outputs.VERSION}}_all.deb


### PR DESCRIPTION
updating upload with v4 as v3 is deprecated and fixing the vm machine to 20.04